### PR TITLE
Allow user specify trusted_arns

### DIFF
--- a/data_sources.tf
+++ b/data_sources.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "admin-trust" {
         [
           aws_iam_role.github.arn
         ],
-        var.admin_allowed_arns
+        var.trusted_arns
       )
     }
   }

--- a/state-manager.tf
+++ b/state-manager.tf
@@ -4,9 +4,12 @@ module "state-manager" {
   providers = {
     aws = aws.tfstates
   }
-  assuming_role_arns = [
-    aws_iam_role.github.arn
-  ]
+  assuming_role_arns = concat(
+    [
+      aws_iam_role.github.arn
+    ],
+    var.trusted_arns
+  )
   name                      = "ih-tf-${var.repo_name}-state-manager"
   state_bucket              = var.state_bucket
   terraform_locks_table_arn = var.terraform_locks_table_arn

--- a/variables.tf
+++ b/variables.tf
@@ -4,8 +4,8 @@ variable "admin_policy_name" {
   default     = "AdministratorAccess"
 }
 
-variable "admin_allowed_arns" {
-  description = "A list of ARNs besides `ih-tf-{var.repo_name}-github` that are allowed to assume the `ih-tf-{var.repo_name}-admin` role."
+variable "trusted_arns" {
+  description = "A list of ARNs besides `ih-tf-{var.repo_name}-github` that are allowed to assume the `ih-tf-{var.repo_name}-admin` and `ih-tf-{var.repo_name}-state-manager` role."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
trusted_arns is a list of ARN that can assume the -github and -admin
roles.
