### PR TITLE
Extend list of allowed ARNs to assumed by `ih-tf-{var.repo_name}-github` role.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ The module creates three IAM roles:
 * `ih-tf-{var.repo_name}-state-manager` - the role can upload/download a Terraform state. 
   The role is created in the "TF states" account by 
   the [state-manager](https://registry.terraform.io/modules/infrahouse/state-manager/aws/latest) module.
-* `ih-tf-{var.repo_name}-github` - the role can only assume the `ih-tf-{var.repo_name}-admin` role. The role is
+* `ih-tf-{var.repo_name}-github` - the role can only assume the `ih-tf-{var.repo_name}-admin`,
+  `ih-tf-{var.repo_name}-state-manager`, and `var.allowed_arns` role.
   The role is created in the CD/CD account.
 
 It's up to a module user to decide what the `*-admin` role can do.
@@ -130,6 +131,7 @@ in `state_bucket` which is `s3://infrahouse-aws-control-493370826424`.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_policy_name"></a> [admin\_policy\_name](#input\_admin\_policy\_name) | Name of the IAM policy the `ih-tf-{var.repo_name}-admin` role will have. This is what the role can do. | `string` | `"AdministratorAccess"` | no |
+| <a name="input_allowed_arns"></a> [allowed\_arns](#input\_allowed\_arns) | A list of ARNs `ih-tf-{var.repo_name}-github` is allowed to assume besides `ih-tf-{var.repo_name}-admin` and `ih-tf-{var.repo_name}-state-manager` roles. | `list(string)` | `[]` | no |
 | <a name="input_gh_org_name"></a> [gh\_org\_name](#input\_gh\_org\_name) | GitHub organization name. | `string` | n/a | yes |
 | <a name="input_repo_name"></a> [repo\_name](#input\_repo\_name) | Repository name in GitHub. Without the organization part. | `any` | n/a | yes |
 | <a name="input_state_bucket"></a> [state\_bucket](#input\_state\_bucket) | Name of the S3 bucket with the state | `any` | n/a | yes |

--- a/data_sources.tf
+++ b/data_sources.tf
@@ -58,9 +58,12 @@ data "aws_iam_policy_document" "github-permissions" {
     actions = [
       "sts:AssumeRole"
     ]
-    resources = [
-      aws_iam_role.admin.arn,
-      module.state-manager.state_manager_role_arn
-    ]
+    resources = concat(
+      [
+        aws_iam_role.admin.arn,
+        module.state-manager.state_manager_role_arn
+      ],
+      var.allowed_arns
+    )
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,9 @@
+variable "allowed_arns" {
+  description = "A list of ARNs `ih-tf-{var.repo_name}-github` is allowed to assume besides `ih-tf-{var.repo_name}-admin` and `ih-tf-{var.repo_name}-state-manager` roles."
+  type        = list(string)
+  default     = []
+}
+
 variable "admin_policy_name" {
   description = "Name of the IAM policy the `ih-tf-{var.repo_name}-admin` role will have. This is what the role can do."
   type        = string


### PR DESCRIPTION
In the previous versions the `ih-tf-{var.repo_name}-github` role could
assume only two roles: ih-tf-{var.repo_name}-admin and
`ih-tf-{var.repo_name}-state-manager`.

This PR extends the list of roles the "github" role is allowed to
assume by adding the variable `allowed_arns` - a list of ARNs.
