### PR TITLE
Add max_session_duration variable with 12h default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ module "gha" {
 * `repo_name` is `aws-control-493370826424` as in https://github.com/infrahouse/aws-control-493370826424.
 * `gha` is a Terraform root module, so it creates actual resources and stores a Terraform state
 in `state_bucket` which is `s3://infrahouse-aws-control-493370826424`.
-
 ## Requirements
 
 | Name | Version |
@@ -109,7 +108,7 @@ in `state_bucket` which is `s3://infrahouse-aws-control-493370826424`.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_state-manager"></a> [state-manager](#module\_state-manager) | infrahouse/state-manager/aws | ~> 0.1 |
+| <a name="module_state-manager"></a> [state-manager](#module\_state-manager) | infrahouse/state-manager/aws | 1.3.0 |
 
 ## Resources
 
@@ -137,6 +136,7 @@ in `state_bucket` which is `s3://infrahouse-aws-control-493370826424`.
 | <a name="input_allow_assume_all_roles"></a> [allow\_assume\_all\_roles](#input\_allow\_assume\_all\_roles) | If true the -github role may assume all possible roles. | `bool` | `false` | no |
 | <a name="input_allowed_arns"></a> [allowed\_arns](#input\_allowed\_arns) | A list of ARNs `ih-tf-{var.repo_name}-github` is allowed to assume besides `ih-tf-{var.repo_name}-admin` and `ih-tf-{var.repo_name}-state-manager` roles. | `list(string)` | `[]` | no |
 | <a name="input_gh_org_name"></a> [gh\_org\_name](#input\_gh\_org\_name) | GitHub organization name. | `string` | n/a | yes |
+| <a name="input_max_session_duration"></a> [max\_session\_duration](#input\_max\_session\_duration) | Maximum session duration (in seconds) that you want to set for the specified role. | `number` | `43200` | no |
 | <a name="input_repo_name"></a> [repo\_name](#input\_repo\_name) | Repository name in GitHub. Without the organization part. | `any` | n/a | yes |
 | <a name="input_state_bucket"></a> [state\_bucket](#input\_state\_bucket) | Name of the S3 bucket with the state | `any` | n/a | yes |
 | <a name="input_terraform_locks_table_arn"></a> [terraform\_locks\_table\_arn](#input\_terraform\_locks\_table\_arn) | DynamoDB table that holds Terraform state locks. | `any` | n/a | yes |

--- a/aws_iam_role.admin.tf
+++ b/aws_iam_role.admin.tf
@@ -1,8 +1,9 @@
 resource "aws_iam_role" "admin" {
-  name               = "ih-tf-${var.repo_name}-admin"
-  description        = "Role to manage AWS account"
-  assume_role_policy = data.aws_iam_policy_document.admin-trust.json
-  tags               = local.tags
+  name                 = "ih-tf-${var.repo_name}-admin"
+  description          = "Role to manage AWS account"
+  assume_role_policy   = data.aws_iam_policy_document.admin-trust.json
+  max_session_duration = var.max_session_duration
+  tags                 = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "admin" {

--- a/aws_iam_role.github.tf
+++ b/aws_iam_role.github.tf
@@ -1,9 +1,10 @@
 resource "aws_iam_role" "github" {
-  provider           = aws.cicd
-  name               = "ih-tf-${var.repo_name}-github"
-  description        = "Role for a GitHub Actions runner in repo ${var.repo_name}"
-  assume_role_policy = data.aws_iam_policy_document.github-trust.json
-  tags               = local.tags
+  provider             = aws.cicd
+  name                 = "ih-tf-${var.repo_name}-github"
+  description          = "Role for a GitHub Actions runner in repo ${var.repo_name}"
+  assume_role_policy   = data.aws_iam_policy_document.github-trust.json
+  max_session_duration = var.max_session_duration
+  tags                 = local.tags
 }
 
 resource "aws_iam_role_policy_attachment" "github" {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black ~= 23.0
+black ~= 24.3
 boto3 ~= 1.26
 infrahouse-toolkit ~= 2.3, >= 2.3.1
 myst-parser ~= 2.0

--- a/state-manager.tf
+++ b/state-manager.tf
@@ -1,6 +1,6 @@
 module "state-manager" {
   source  = "infrahouse/state-manager/aws"
-  version = "~> 0.1"
+  version = "1.3.0"
   providers = {
     aws = aws.tfstates
   }
@@ -13,4 +13,5 @@ module "state-manager" {
   name                      = "ih-tf-${var.repo_name}-state-manager"
   state_bucket              = var.state_bucket
   terraform_locks_table_arn = var.terraform_locks_table_arn
+  max_session_duration      = var.max_session_duration
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,12 @@ variable "gh_org_name" {
   type        = string
 }
 
+variable "max_session_duration" {
+  description = "Maximum session duration (in seconds) that you want to set for the specified role."
+  type        = number
+  default     = 12 * 3600
+}
+
 variable "repo_name" {
   description = "Repository name in GitHub. Without the organization part."
 }


### PR DESCRIPTION
A role has a one hour default session duration. It is not enough, as a `terraform apply` can run more than that.
Adding the `max_session_duration` variable and set it to 12 hours as the default value.
