### PR TITLE
Truncate state-manager role name at 64 characters

### DIFF
--- a/state-manager.tf
+++ b/state-manager.tf
@@ -10,7 +10,7 @@ module "state-manager" {
     ],
     var.trusted_arns
   )
-  name                      = "ih-tf-${var.repo_name}-state-manager"
+  name                      = substr("ih-tf-${var.repo_name}-state-manager", 0, 64)
   state_bucket              = var.state_bucket
   terraform_locks_table_arn = var.terraform_locks_table_arn
 }


### PR DESCRIPTION
This is AWS limit.
