### PR TITLE
feat!: bump state-manager to 1.5.0, add environment, state_key, trusted_arn_patterns

### DIFF
--- a/data_sources.tf
+++ b/data_sources.tf
@@ -25,6 +25,22 @@ data "aws_iam_policy_document" "admin-trust" {
       )
     }
   }
+
+  dynamic "statement" {
+    for_each = length(var.trusted_arn_patterns) > 0 ? [1] : []
+    content {
+      actions = ["sts:AssumeRole"]
+      principals {
+        type        = "AWS"
+        identifiers = ["*"]
+      }
+      condition {
+        test     = "StringLike"
+        variable = "aws:PrincipalArn"
+        values   = var.trusted_arn_patterns
+      }
+    }
+  }
 }
 
 data "aws_iam_policy_document" "github-trust" {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,16 @@
 
 ## Required Variables
 
+### `environment`
+
+- **Type**: `string`
+- **Description**: Environment name (e.g., `development`, `staging`, `production`).
+  Must contain only lowercase letters, numbers, and underscores.
+
+```hcl
+environment = "production"
+```
+
 ### `gh_org_name`
 
 - **Type**: `string`
@@ -105,6 +115,39 @@ trusted_arns = [
   "arn:aws:iam::CICD_ACCOUNT:role/admin",
 ]
 ```
+
+### `state_key`
+
+- **Type**: `string`
+- **Default**: `"terraform.tfstate"`
+- **Description**: Path to the Terraform state file in the S3 bucket. Passed through to the
+  state-manager sub-module to scope IAM permissions to the correct S3 object path.
+  Set this when your backend uses a subdirectory key.
+
+```hcl
+# For a repo with per-environment state files
+state_key = "sandbox/terraform.tfstate"
+```
+
+### `trusted_arn_patterns`
+
+- **Type**: `list(string)`
+- **Default**: `[]`
+- **Description**: ARN patterns (with wildcards) for roles allowed to assume the admin
+  and state-manager roles. Uses `StringLike` condition on `aws:PrincipalArn` instead of
+  exact matching. Useful for AWS SSO roles whose ARN suffix changes when the permission
+  set is recreated. Each pattern must include an explicit 12-digit AWS account ID.
+
+```hcl
+trusted_arn_patterns = [
+  "arn:aws:iam::990466748045:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AWSAdministratorAccess_*",
+]
+```
+
+!!! tip
+    Use `trusted_arn_patterns` instead of `trusted_arns` for AWS SSO roles. SSO role ARNs
+    contain an auto-generated suffix that changes whenever the permission set is recreated,
+    which would break exact-match trust policies.
 
 ### `max_session_duration`
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -13,6 +13,7 @@ module "gha" {
     aws.cicd     = aws
     aws.tfstates = aws
   }
+  environment               = "production"
   gh_org_name               = "my-org"
   repo_name                 = "my-repo"
   state_bucket              = "my-terraform-states"
@@ -54,6 +55,7 @@ module "gha" {
     aws.cicd     = aws.cicd
     aws.tfstates = aws.tfstates
   }
+  environment               = "production"
   gh_org_name               = "my-org"
   repo_name                 = "my-repo"
   state_bucket              = module.state-bucket.bucket_name
@@ -74,6 +76,7 @@ module "gha" {
     aws.cicd     = aws.cicd
     aws.tfstates = aws.tfstates
   }
+  environment               = "production"
   gh_org_name               = "my-org"
   repo_name                 = "my-repo"
   state_bucket              = module.state-bucket.bucket_name
@@ -97,6 +100,7 @@ module "gha" {
     aws.cicd     = aws.cicd
     aws.tfstates = aws.tfstates
   }
+  environment               = "production"
   gh_org_name               = "my-org"
   repo_name                 = "my-repo"
   state_bucket              = module.state-bucket.bucket_name
@@ -123,6 +127,7 @@ module "gha" {
     aws.cicd     = aws.cicd
     aws.tfstates = aws.tfstates
   }
+  environment               = "production"
   gh_org_name               = "my-org"
   repo_name                 = "aws-control"
   state_bucket              = module.state-bucket.bucket_name
@@ -146,6 +151,7 @@ module "gha" {
     aws.cicd     = aws.cicd
     aws.tfstates = aws.tfstates
   }
+  environment               = "production"
   gh_org_name               = "my-org"
   repo_name                 = "my-repo"
   state_bucket              = module.state-bucket.bucket_name
@@ -154,6 +160,57 @@ module "gha" {
   # Allow an admin role from the CI/CD account to also assume these roles
   trusted_arns = [
     "arn:aws:iam::111111111111:role/admin",
+  ]
+}
+```
+
+## Custom State Key
+
+When your backend uses a subdirectory key (e.g., per-environment state files):
+
+```hcl
+module "gha_sandbox" {
+  source  = "registry.infrahouse.com/infrahouse/gha-admin/aws"
+  version = "3.6.1"
+  providers = {
+    aws          = aws
+    aws.cicd     = aws.cicd
+    aws.tfstates = aws.tfstates
+  }
+  environment               = "sandbox"
+  gh_org_name               = "my-org"
+  repo_name                 = "my-repo"
+  state_bucket              = module.state-bucket.bucket_name
+  terraform_locks_table_arn = module.state-bucket.lock_table_arn
+
+  # Match the backend key so the state-manager IAM policy allows access
+  state_key = "sandbox/terraform.tfstate"
+}
+```
+
+## AWS SSO Trusted Principals
+
+Use `trusted_arn_patterns` for AWS SSO roles whose ARN suffix changes when the
+permission set is recreated:
+
+```hcl
+module "gha" {
+  source  = "registry.infrahouse.com/infrahouse/gha-admin/aws"
+  version = "3.6.1"
+  providers = {
+    aws          = aws
+    aws.cicd     = aws.cicd
+    aws.tfstates = aws.tfstates
+  }
+  environment               = "production"
+  gh_org_name               = "my-org"
+  repo_name                 = "my-repo"
+  state_bucket              = module.state-bucket.bucket_name
+  terraform_locks_table_arn = module.state-bucket.lock_table_arn
+
+  # Wildcard pattern survives SSO permission set recreation
+  trusted_arn_patterns = [
+    "arn:aws:iam::990466748045:role/aws-reserved/sso.amazonaws.com/*/AWSReservedSSO_AWSAdministratorAccess_*",
   ]
 }
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -104,6 +104,7 @@ module "gha" {
     aws.cicd     = aws.cicd
     aws.tfstates = aws.tfstates
   }
+  environment               = "production"
   gh_org_name               = "my-org"
   repo_name                 = "my-repo"
   state_bucket              = module.state-bucket.bucket_name

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ module "gha" {
     aws.cicd     = aws.cicd
     aws.tfstates = aws.tfstates
   }
+  environment               = "production"
   gh_org_name               = "my-org"
   repo_name                 = "my-repo"
   state_bucket              = module.state-bucket.bucket_name

--- a/local.tf
+++ b/local.tf
@@ -1,6 +1,7 @@
 locals {
   module_version = "3.6.1"
   tags = {
-    created_by_module : "infrahouse/gha-admin/aws"
+    environment       = var.environment
+    created_by_module = "infrahouse/gha-admin/aws"
   }
 }

--- a/state-manager.tf
+++ b/state-manager.tf
@@ -1,9 +1,11 @@
 module "state-manager" {
   source  = "infrahouse/state-manager/aws"
-  version = "1.4.2"
+  version = "1.5.0"
   providers = {
     aws = aws.tfstates
   }
+  environment            = var.environment
+  assuming_role_patterns = var.trusted_arn_patterns
   assuming_role_arns = concat(
     [
       aws_iam_role.github.arn
@@ -12,6 +14,7 @@ module "state-manager" {
   )
   name                      = substr("ih-tf-${var.repo_name}-state-manager", 0, 64)
   state_bucket              = var.state_bucket
+  state_key                 = var.state_key
   terraform_locks_table_arn = var.terraform_locks_table_arn
   max_session_duration      = var.max_session_duration
 }

--- a/test_data/gha-admin/main.tf
+++ b/test_data/gha-admin/main.tf
@@ -24,6 +24,7 @@ module "gha" {
     aws.cicd     = aws
     aws.tfstates = aws
   }
+  environment               = var.environment
   gh_org_name               = var.gh_org_name
   repo_name                 = var.repo_name
   state_bucket              = aws_s3_bucket.pytest.bucket

--- a/test_data/gha-admin/terraform.tfvars
+++ b/test_data/gha-admin/terraform.tfvars
@@ -1,2 +1,3 @@
+environment = "development"
 gh_org_name = "foo-org"
 repo_name   = "foo-repo"

--- a/test_data/gha-admin/variables.tf
+++ b/test_data/gha-admin/variables.tf
@@ -1,3 +1,8 @@
+variable "environment" {
+  description = "Environment name."
+  type        = string
+}
+
 variable "gh_org_name" {
   description = "GitHub organization name."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,13 @@
+variable "environment" {
+  description = "Environment name (e.g., development, staging, production)."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9_]+$", var.environment))
+    error_message = "environment must contain only lowercase letters, numbers, and underscores. Got: ${var.environment}."
+  }
+}
+
 variable "allowed_arns" {
   description = <<-EOT
     A list of ARNs `ih-tf-{var.repo_name}-github` is allowed to assume
@@ -28,6 +38,24 @@ variable "trusted_arns" {
   default     = []
 }
 
+variable "trusted_arn_patterns" {
+  description = <<-EOT
+    ARN patterns (with wildcards) for roles allowed to assume the admin and state-manager roles.
+    Uses StringLike condition on aws:PrincipalArn instead of exact matching.
+    Useful for AWS SSO roles with auto-generated suffixes that change when permission sets are recreated.
+    Each pattern must include an explicit 12-digit AWS account ID.
+  EOT
+  type        = list(string)
+  default     = []
+
+  validation {
+    condition = alltrue([
+      for p in var.trusted_arn_patterns : can(regex("^arn:aws:iam::[0-9]{12}:", p))
+    ])
+    error_message = "Each trusted_arn_patterns entry must start with 'arn:aws:iam::' followed by a 12-digit account ID."
+  }
+}
+
 variable "gh_org_name" {
   description = "GitHub organization name."
   type        = string
@@ -52,6 +80,17 @@ variable "max_session_duration" {
 variable "repo_name" {
   description = "Repository name in GitHub. Without the organization part."
   type        = string
+}
+
+variable "state_key" {
+  description = "Path to the Terraform state file in the S3 bucket. Passed through to the state-manager sub-module."
+  type        = string
+  default     = "terraform.tfstate"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9/_.-]+$", var.state_key))
+    error_message = "state_key must contain only alphanumeric characters, slashes, underscores, dots, and hyphens. Got: ${var.state_key}"
+  }
 }
 
 variable "state_bucket" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,10 @@ variable "environment" {
 
   validation {
     condition     = can(regex("^[a-z0-9_]+$", var.environment))
-    error_message = "environment must contain only lowercase letters, numbers, and underscores. Got: ${var.environment}."
+    error_message = <<-EOT
+      environment must contain only lowercase letters, numbers, and underscores.
+      Got: ${var.environment}
+    EOT
   }
 }
 
@@ -50,9 +53,15 @@ variable "trusted_arn_patterns" {
 
   validation {
     condition = alltrue([
-      for p in var.trusted_arn_patterns : can(regex("^arn:aws:iam::[0-9]{12}:", p))
+      for p in var.trusted_arn_patterns :
+      can(regex("^arn:aws:iam::[0-9]{12}:(role|user|assumed-role)/[^*]+", p))
     ])
-    error_message = "Each trusted_arn_patterns entry must start with 'arn:aws:iam::' followed by a 12-digit account ID."
+    error_message = <<-EOT
+      Each trusted_arn_patterns entry must be of the form
+      'arn:aws:iam::<account_id>:(role|user|assumed-role)/<path>' with at least one non-wildcard
+      character in the resource path. Account-wide patterns like ':*' or ':role/*' are not allowed.
+      Got: ${jsonencode(var.trusted_arn_patterns)}
+    EOT
   }
 }
 
@@ -83,13 +92,19 @@ variable "repo_name" {
 }
 
 variable "state_key" {
-  description = "Path to the Terraform state file in the S3 bucket. Passed through to the state-manager sub-module."
+  description = <<-EOT
+    Path to the Terraform state object inside var.state_bucket (matches the backend "key" argument).
+    The state-manager IAM policy is scoped to this path, so the value MUST match the backend config.
+  EOT
   type        = string
   default     = "terraform.tfstate"
 
   validation {
     condition     = can(regex("^[a-zA-Z0-9/_.-]+$", var.state_key))
-    error_message = "state_key must contain only alphanumeric characters, slashes, underscores, dots, and hyphens. Got: ${var.state_key}"
+    error_message = <<-EOT
+      state_key must contain only alphanumeric characters, slashes, underscores, dots, and hyphens.
+      Got: ${var.state_key}
+    EOT
   }
 }
 


### PR DESCRIPTION
## Summary

- **BREAKING**: Add required `environment` variable (no default), passed through to state-manager 1.5.0
- Add `state_key` variable to scope state-manager IAM policy to the correct S3 object path. Closes #24
- Add `trusted_arn_patterns` for wildcard `StringLike` trust policies on admin and state-manager roles (useful for AWS SSO roles with auto-generated suffixes)
- Bump `infrahouse/state-manager/aws` from 1.4.2 to 1.5.0
- Update all documentation and examples

## Test plan

- [x] `make test` passes (tests updated with `environment` variable)
- [ ] Existing callers verified to need only `environment` addition (backward-compatible otherwise)
- [ ] Verify `state_key` pass-through scopes IAM policy correctly for subdirectory keys
- [ ] Verify `trusted_arn_patterns` produces correct `StringLike` condition in admin trust policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)